### PR TITLE
Hotfix/fix cookie auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,40 +5,25 @@ Todas as mudanças notáveis neste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/),
 e este projeto adere ao [Semantic Versioning](https://semver.org/lang/pt-BR/).
 
-## [1.0.0] - 2025-11-06
+## [1.0.1] - 2025-11-07
 
-### Adicionado
+### Corrigido
 
-- Autenticação com JWT e três roles (ADMIN, INSTRUCTOR, STUDENT)
-- Sistema de convites hierárquico (ADMIN convida INSTRUCTOR, INSTRUCTOR convida STUDENT)
-- Cadastro de usuários via convite com validação de token
-- Gerenciamento de turmas (criação, listagem, detalhes)
-- Gerenciamento de instrutores (listagem, exclusão, alteração de status)
-- Sistema de convites completo (envio, listagem, exclusão, reenvio)
-- Paginação, busca e ordenação em listagens
-- API REST com documentação via Swagger/OpenAPI
-- Envio de emails transacionais via SMTP (dev) ou Resend (prod)
-- Estrutura em camadas (4 controllers, 5 services, múltiplos repositories)
-- Docker e Docker Compose para ambiente completo (API + PostgreSQL)
-- Configurações por perfil (dev/prod)
-- Health checks via Spring Boot Actuator
-- Tratamento centralizado de exceções com respostas padronizadas
-- Validação de dados com Bean Validation
-- Filtros de segurança (JWT, validação de origem)
-- CORS configurável por ambiente
-- Cookies HttpOnly para armazenamento seguro de tokens
-- Templates HTML responsivos para emails de convite
-- Controle de reenvio de convites (proteção contra spam - 2 horas)
-- Relacionamento aluno-turma com matrícula
-- Utilitários para JWT, cookies e respostas padronizadas
-- Testes unitários para serviços, controllers e filtros
-- Ferramentas de qualidade (Spotless, Checkstyle, OWASP Dependency Check)
+- Configuração de cookies de autenticação para permitir uso entre domínios (`.tech` e `.vercel.app`):
+    - `cookie.same-site` alterado de `Strict` para `None`
+    - Remoção do domínio fixo do cookie (`server.servlet.session.cookie.domain`)
+    - Mantidos: `Secure=true` e `HttpOnly=true`
+- Erro de login onde o navegador bloqueava o cookie por domínio inválido.
 
-### Nota
+### Ajustado
 
-Funcionalidades anteriores à versão 1.0.0 foram consolidadas nesta versão inicial.
-Para documentação detalhada, consulte [docs/release-notes/v1.0.0.md](docs/release-notes/v1.0.0.md).
+- Configuração do pool de conexões (HikariCP) para evitar falhas por conexões esgotadas:
+    - `maximum-pool-size` definido em `8`
+    - `minimum-idle` em `2`
+    - Tempo de ociosidade, timeout e lifetime ajustados para garantir estabilidade.
 
----
+### Notas
 
-[1.0.0]: https://github.com/issaahr/educa-games-api/releases/tag/v1.0.0
+- Sem alterações no banco de dados.
+- Sem breaking changes.
+- Apenas redeploy foi necessário.

--- a/docs/release-notes/v1.0.1.md
+++ b/docs/release-notes/v1.0.1.md
@@ -1,0 +1,51 @@
+# Release Notes - Versão 1.0.1
+
+Hotfix para corrigir a configuração de cookies de autenticação e ajustar o pool de conexões com o banco de dados.
+
+## Visão Geral
+
+Atualização incremental da versão 1.0.0, sem inclusão de novas funcionalidades. Foco exclusivo em correções de segurança e estabilidade.
+
+---
+
+## Correções Aplicadas
+
+### Cookies de Autenticação
+
+- Ajuste para permitir autenticação entre domínios diferentes (backend em `.tech` e frontend em `.vercel.app`).
+- Alterações aplicadas:
+    - `cookie.same-site=Strict` → `cookie.same-site=None`
+    - Remoção de `server.servlet.session.cookie.domain=.educagames.com` (agora vazio para evitar bloqueio do navegador)
+- Mantidos:
+    - `Secure=true`
+    - `HttpOnly=true`
+
+Essas alterações garantem que o navegador aceite o cookie de autenticação em requisições cross-site.
+
+---
+
+### Pool de Conexões com o Banco (HikariCP)
+
+Configurações adicionadas para evitar falhas por esgotamento de conexões e melhorar a estabilidade da API.
+
+```properties
+spring.datasource.hikari.maximum-pool-size=8
+spring.datasource.hikari.minimum-idle=2
+spring.datasource.hikari.idle-timeout=30000
+spring.datasource.hikari.max-lifetime=540000
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.leak-detection-threshold=20000
+```
+
+---
+
+## Notas
+
+- Não houve alteração no banco de dados.
+- Não há breaking changes.
+- Apenas redeploy da aplicação foi necessário.
+- A versão 1.0.0 permanece como base estável.
+
+---
+
+[Voltar para CHANGELOG.md](../../CHANGELOG.md)

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,8 +1,8 @@
 # Cookie
 cookie.max-age=3600
 cookie.secure=true
-cookie.same-site=Strict
-server.servlet.session.cookie.domain=.educagames.com
+cookie.same-site=None
+server.servlet.session.cookie.domain=
 
 #Logging
 logging.level.root=WARN

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,9 +15,16 @@ app.frontend.url=${FRONTEND_URL}
 app.logo.public-url=${LOGO_URL}
 app.invite.signup-token-expiration-hours=${SIGNUP_TOKEN_EXPIRATION}
 
-# Instructor emails for seeding
-instructor.emails=${INSTRUCTOR_EMAILS}
+# CORS
 cors.allowed-origins=${CORS_ALLOWED_ORIGINS}
+
+# Datasource Pool
+spring.datasource.hikari.maximum-pool-size=8
+spring.datasource.hikari.minimum-idle=2
+spring.datasource.hikari.idle-timeout=30000
+spring.datasource.hikari.max-lifetime=540000
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.leak-detection-threshold=20000
 
 # Admin user for seeding
 admin.password=${ADMIN_PASSWORD}


### PR DESCRIPTION
## Descrição

Este PR resolve problemas de autenticação entre frontend (Vercel) e backend, corrigindo a configuração de cookies e ajustando o pool de conexões com o banco de dados.

### Principais ajustes:
- Alteração do `SameSite` do cookie de `Strict` para `None`.
- Remoção do domínio fixo `.educagames.com` para evitar bloqueio do navegador.
- Cookie permanece com `HttpOnly` e `Secure`.
- Ajuste do pool de conexões HikariCP para evitar falhas de conexão e instabilidade da API.

## Tipo de mudança

- [x] Correção de bug
- [ ] Nova funcionalidade
- [ ] Refatoração
- [ ] Quebra compatibilidade

## Checklist

- [x] Código testado localmente
- [x] Sem erros ou warnings no build
- [x] Atualizei documentação/CHANGELOG